### PR TITLE
Add prompt templates and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,16 @@ To perform a code audit using an AI agent:
 ### Example AI Agent Prompt
 
 ```
-Please analyze the codebase at [PATH] using the specifications in the ai-code-auditor/specs/ folder. 
+Please analyze the codebase at [PATH] using the specifications in the ai-code-auditor/specs/ folder.
 Focus on detecting design patterns and provide a detailed report including:
 - Pattern instances found
 - Implementation quality assessment
 - Recommendations for improvements
 ```
+
+### Prompt Library
+
+Ready-made prompt templates are available in the [`prompts/`](prompts/) directory. Copy the appropriate file and replace `[CODE_PATH]` with the path to your codebase or metadata repository. Templates include design pattern scans, algorithm and data structure analysis, DataHub metadata audits, and ETL subsystem checks.
 
 ## Specification Schema
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,10 @@
+# Prompt Examples
+
+This folder provides ready-made prompt templates for guiding an AI agent when scanning a codebase with the specifications and documentation in this repository.
+
+- **design-patterns-prompt.md** – analyze code for GoF and architectural design patterns
+- **algorithms-ds-prompt.md** – detect algorithms and data structures with complexity analysis
+- **datahub-prompt.md** – audit metadata against DataHub entity and aspect standards
+- **etl-subsystems-prompt.md** – inspect ETL implementations for Kimball subsystems
+
+Copy the contents of any prompt file into your AI tool and replace `[CODE_PATH]` with the path to the code or metadata you want to analyze.

--- a/prompts/algorithms-ds-prompt.md
+++ b/prompts/algorithms-ds-prompt.md
@@ -1,0 +1,13 @@
+# Algorithms & Data Structures Scan Prompt
+
+Use this prompt to detect algorithms and data structures in a codebase using the provided specs and taxonomy.
+
+```text
+You are an AI code auditor. Utilize `specs/algorithms-data-structures-spec.yaml` and `docs/Algorithms-DS-Taxonomy.md` to analyze the code at [CODE_PATH].
+
+Identify implementations of algorithms and data structures. For each one, provide:
+- File location
+- Time and space complexity notes
+- Quality metrics from the spec `report_fields`
+- Suggestions for optimization
+```

--- a/prompts/datahub-prompt.md
+++ b/prompts/datahub-prompt.md
@@ -1,0 +1,13 @@
+# DataHub Metadata Scan Prompt
+
+Use this prompt with your AI agent to audit DataHub entities and aspects.
+
+```text
+You are an AI code auditor. Refer to `specs/datahub-spec.yaml` along with `docs/DataHub-Taxonomy-Reference.md` to examine metadata at [CODE_PATH] or within your DataHub instance.
+
+Report on each recognized entity and aspect:
+- URNs or file references
+- Aspect completeness based on the spec `report_fields`
+- Governance or lineage issues
+- Suggested improvements to metadata quality
+```

--- a/prompts/design-patterns-prompt.md
+++ b/prompts/design-patterns-prompt.md
@@ -1,0 +1,13 @@
+# Design Patterns Scan Prompt
+
+Use this prompt with your AI agent to analyze a codebase for design pattern usage using the specification and documentation in this repository.
+
+```text
+You are an AI code auditor. Apply the rules defined in `specs/design-patterns-spec.yaml` together with the guidance in `docs/Design-Patterns-Taxonomy.md` to scan the target code at [CODE_PATH].
+
+For each detected design pattern, report:
+- File locations
+- Relevant code snippets
+- Implementation quality using the `report_fields` from the spec
+- Recommendations for improvement
+```

--- a/prompts/etl-subsystems-prompt.md
+++ b/prompts/etl-subsystems-prompt.md
@@ -1,0 +1,13 @@
+# ETL Subsystems Scan Prompt
+
+Use this prompt to analyze ETL architectures against the 38 subsystems taxonomy.
+
+```text
+You are an AI code auditor. Apply `specs/etl-subsystems-spec.yaml` alongside the explanations in `docs/ETL-Subsystems-Taxonomy.md` to inspect the ETL code or documentation at [CODE_PATH].
+
+For each subsystem detected, describe:
+- Where it appears in the codebase
+- Whether it is complete or missing required components
+- Any integration or scalability concerns
+- Recommendations to achieve the maturity levels outlined in the taxonomy
+```


### PR DESCRIPTION
## Summary
- add `prompts` directory with example prompt templates for each spec
- document the prompt library in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68745e1920f0832da42f18b46d6100a9