### PR TITLE
Add cloud architecture specifications

### DIFF
--- a/docs/Cloud-Architecture-Taxonomy.md
+++ b/docs/Cloud-Architecture-Taxonomy.md
@@ -1,0 +1,67 @@
+# Cloud Architecture Taxonomy
+
+This document catalogs common cloud architecture patterns and services across major providers. The AI code auditor uses these references to detect usage, governance gaps, and cost issues.
+
+## AWS Patterns
+
+| Pattern | Key Concepts | Cost Optimization | Compliance Focus |
+|---------|--------------|-------------------|-----------------|
+| **EC2 Instance** | Virtual machine provisioning, auto scaling | Right-sizing instances, reserved instances | Security groups, encryption |
+| **Lambda Function** | Event-driven compute, serverless | Memory tuning, short timeouts | IAM roles, logging |
+| **S3 Bucket** | Object storage, lifecycle policies | Lifecycle rules, infrequent tiers | Public access, encryption |
+| **RDS Instance** | Managed relational DB, multi-AZ | Storage autoscaling, reserved DB instances | Backup retention, encryption |
+| **CloudFormation/CDK** | Infrastructure as Code templates | Stack reuse, modular design | Change sets, IAM roles |
+| **IAM Policy** | Access management documents | Least privilege policies | Policy length, resource scoping |
+| **VPC Configuration** | Networking isolation, security groups | Peering vs. NAT costs | CIDR planning, firewall rules |
+
+## Azure Patterns
+
+| Pattern | Key Concepts | Cost Optimization | Compliance Focus |
+|---------|--------------|-------------------|-----------------|
+| **Azure Function** | Serverless compute, consumption plan | Plan sizing, cold start reduction | Managed identities, logging |
+| **Azure App Service** | Web app hosting, deployment slots | Right-size plans, auto-scale | Authentication, diagnostics |
+| **ARM Template** | Declarative infrastructure, Bicep | Parameter reuse, template modularity | Role assignments, resource locks |
+| **Azure AD Integration** | Identity and access, service principals | Conditional access policies | Least privilege roles |
+| **Azure Storage** | Blob, queue, table services | Archive tier, access tiers | Network rules, encryption |
+
+## GCP Patterns
+
+| Pattern | Key Concepts | Cost Optimization | Compliance Focus |
+|---------|--------------|-------------------|-----------------|
+| **Compute Engine** | VM instances, instance templates | Committed use discounts | Firewall rules, service accounts |
+| **Cloud Function** | Event-driven compute, HTTP triggers | Optimize memory and timeout | IAM roles, log retention |
+| **Deployment Manager** | Infrastructure as Code, templates | Reusable templates | IAM bindings, audit logging |
+| **GCP IAM Policy** | Roles and bindings | Principle of least privilege | Service account scoping |
+| **Cloud Storage** | Bucket storage, retention policies | Nearline & Coldline tiers | Bucket policy, encryption |
+
+## Multi-Cloud & Kubernetes
+
+| Pattern | Key Concepts | Cost Optimization | Compliance Focus |
+|---------|--------------|-------------------|-----------------|
+| **Terraform Module** | Declarative resource provisioning | Module reuse, shared state | Provider credentials |
+| **Kubernetes Manifest** | Pod and deployment specs | Resource limits, autoscale | Namespace policies |
+| **Helm Chart** | Templated Kubernetes apps | Values overrides, chart reuse | Release security settings |
+| **Service Mesh** | Networking control plane | Efficient traffic routing | Mutual TLS, policy enforcement |
+
+## Cloud-Native Patterns
+
+| Pattern | Key Concepts | Cost Optimization | Compliance Focus |
+|---------|--------------|-------------------|-----------------|
+| **Microservices Architecture** | Small, independent services | Container right-sizing | API gateway policies |
+| **Event-Driven Architecture** | Async messaging, pub/sub | Scale consumers on demand | Message retention, ACLs |
+| **Serverless Pattern** | Functions as a service | Pay-per-use, cold start control | Logging, IAM policies |
+| **Container Orchestration** | Kubernetes, Docker Swarm | Cluster autoscaling | RBAC, network policies |
+
+### Common Compliance Checks
+
+- **Least Privilege**: Ensure IAM policies or role assignments grant only necessary permissions.
+- **Encryption**: Verify encryption at rest and in transit for storage and databases.
+- **Logging**: Confirm that audit and access logs are enabled and retained.
+- **Network Security**: Validate firewall rules, VPC/VNet isolation, and service mesh policies.
+
+### Cost Optimization Hints
+
+- **Right-Sizing**: Analyze resource utilization to select appropriate instance sizes and plans.
+- **Reserved Capacity**: Leverage reserved or committed use discounts for long-running workloads.
+- **Lifecycle Policies**: Use storage lifecycle rules to transition data to cheaper tiers.
+- **Autoscaling**: Configure auto scaling to match demand and avoid overprovisioning.

--- a/prompts/cloud-audit-prompts.md
+++ b/prompts/cloud-audit-prompts.md
@@ -1,0 +1,12 @@
+# Cloud Architecture Audit Prompt
+
+Use this prompt to analyze a codebase or infrastructure repository for cloud architecture patterns, cost optimization, and compliance issues.
+
+```text
+You are an AI code auditor. Apply `specs/cloud-architecture-spec.yaml` along with `docs/Cloud-Architecture-Taxonomy.md` to examine the resources at [CODE_PATH].
+
+For each detected pattern or service:
+- Provide the file or configuration location
+- Summarize the deployment details and any cost optimization opportunities
+- Highlight compliance or governance concerns
+```

--- a/specs/cloud-architecture-spec.yaml
+++ b/specs/cloud-architecture-spec.yaml
@@ -1,0 +1,297 @@
+cloud_architecture_patterns:
+  # AWS Patterns
+  - name: "EC2 Instance"
+    category: "aws"
+    hints:
+      - "aws_instance"
+      - "ec2"
+      - "launch configuration"
+      - "autoscaling group"
+    report_fields:
+      - "instance_type"
+      - "scaling_strategy"
+      - "networking"
+      - "cost_estimation"
+  - name: "Lambda Function"
+    category: "aws"
+    hints:
+      - "aws_lambda_function"
+      - "lambda_handler"
+      - "serverless.yml"
+      - "event source mapping"
+    report_fields:
+      - "runtime"
+      - "memory_size"
+      - "timeout"
+      - "cost_estimation"
+  - name: "S3 Bucket"
+    category: "aws"
+    hints:
+      - "aws_s3_bucket"
+      - "bucket policy"
+      - "public-read"
+      - "lifecycle rule"
+    report_fields:
+      - "versioning"
+      - "encryption"
+      - "access_control"
+      - "cost_estimation"
+  - name: "RDS Instance"
+    category: "aws"
+    hints:
+      - "aws_db_instance"
+      - "rds"
+      - "parameter group"
+      - "subnet group"
+    report_fields:
+      - "engine"
+      - "instance_class"
+      - "backup_retention"
+      - "cost_estimation"
+  - name: "CloudFormation or CDK"
+    category: "aws"
+    hints:
+      - "cloudformation"
+      - "cdk"
+      - "stack"
+      - "template.yaml"
+    report_fields:
+      - "stack_name"
+      - "resources_defined"
+      - "parameter_usage"
+      - "cost_estimation"
+  - name: "IAM Policy"
+    category: "aws"
+    hints:
+      - "aws_iam_policy"
+      - "policy document"
+      - "assume role"
+      - "least privilege"
+    report_fields:
+      - "privilege_scope"
+      - "resource_restrictions"
+      - "policy_size"
+      - "compliance_check"
+  - name: "VPC Configuration"
+    category: "aws"
+    hints:
+      - "aws_vpc"
+      - "subnet"
+      - "route table"
+      - "security group"
+    report_fields:
+      - "cidr_blocks"
+      - "public_private_split"
+      - "firewall_rules"
+      - "compliance_check"
+
+  # Azure Patterns
+  - name: "Azure Function"
+    category: "azure"
+    hints:
+      - "azurerm_function_app"
+      - "func.azurewebsites.net"
+      - "function.json"
+      - "Durable Functions"
+    report_fields:
+      - "runtime"
+      - "plan_type"
+      - "app_settings"
+      - "cost_estimation"
+  - name: "Azure App Service"
+    category: "azure"
+    hints:
+      - "azurerm_app_service"
+      - "webapp"
+      - "app service plan"
+      - "deployment slot"
+    report_fields:
+      - "sku"
+      - "scaling"
+      - "diagnostics"
+      - "cost_estimation"
+  - name: "ARM Template"
+    category: "azure"
+    hints:
+      - "azuredeploy.json"
+      - "arm template"
+      - "bicep"
+    report_fields:
+      - "resources_defined"
+      - "parameters"
+      - "outputs"
+      - "cost_estimation"
+  - name: "Azure AD Integration"
+    category: "azure"
+    hints:
+      - "azuread_application"
+      - "service principal"
+      - "oauth2Permissions"
+      - "rbac"
+    report_fields:
+      - "app_roles"
+      - "permission_scopes"
+      - "conditional_access"
+      - "compliance_check"
+  - name: "Azure Storage"
+    category: "azure"
+    hints:
+      - "azurerm_storage_account"
+      - "blob service"
+      - "queue service"
+      - "table service"
+    report_fields:
+      - "redundancy"
+      - "access_tier"
+      - "network_rules"
+      - "cost_estimation"
+
+  # GCP Patterns
+  - name: "Compute Engine"
+    category: "gcp"
+    hints:
+      - "google_compute_instance"
+      - "gcloud compute"
+      - "instance_template"
+    report_fields:
+      - "machine_type"
+      - "boot_disk"
+      - "network_tags"
+      - "cost_estimation"
+  - name: "Cloud Function"
+    category: "gcp"
+    hints:
+      - "google_cloudfunctions_function"
+      - "index.js"
+      - "requirements.txt"
+    report_fields:
+      - "runtime"
+      - "memory"
+      - "trigger"
+      - "cost_estimation"
+  - name: "Deployment Manager"
+    category: "gcp"
+    hints:
+      - "deployment manager"
+      - "config.yaml"
+      - "jinja"
+    report_fields:
+      - "resources_defined"
+      - "imports"
+      - "outputs"
+      - "cost_estimation"
+  - name: "GCP IAM Policy"
+    category: "gcp"
+    hints:
+      - "gcp_iam_policy"
+      - "serviceAccount"
+      - "roles/"
+    report_fields:
+      - "role_bindings"
+      - "service_accounts"
+      - "condition_policies"
+      - "compliance_check"
+  - name: "Cloud Storage"
+    category: "gcp"
+    hints:
+      - "google_storage_bucket"
+      - "bucket policy"
+      - "nearline"
+    report_fields:
+      - "location"
+      - "versioning"
+      - "encryption"
+      - "cost_estimation"
+
+  # Multi-Cloud & Kubernetes
+  - name: "Terraform Module"
+    category: "multi-cloud"
+    hints:
+      - "terraform module"
+      - "variables.tf"
+      - "outputs.tf"
+    report_fields:
+      - "providers"
+      - "resource_count"
+      - "reusability"
+      - "compliance_check"
+  - name: "Kubernetes Manifest"
+    category: "multi-cloud"
+    hints:
+      - "apiVersion: v1"
+      - "kind: Pod"
+      - "kind: Deployment"
+    report_fields:
+      - "resource_limits"
+      - "replicas"
+      - "namespace"
+      - "cost_estimation"
+  - name: "Helm Chart"
+    category: "multi-cloud"
+    hints:
+      - "Chart.yaml"
+      - "values.yaml"
+      - "helm install"
+    report_fields:
+      - "chart_version"
+      - "config_overrides"
+      - "release_name"
+      - "cost_estimation"
+  - name: "Service Mesh"
+    category: "multi-cloud"
+    hints:
+      - "istio"
+      - "linkerd"
+      - "envoy proxy"
+    report_fields:
+      - "mTLS"
+      - "traffic_policy"
+      - "observability"
+      - "compliance_check"
+
+  # Cloud-Native Patterns
+  - name: "Microservices Architecture"
+    category: "cloud-native"
+    hints:
+      - "service registry"
+      - "api gateway"
+      - "bounded context"
+    report_fields:
+      - "service_count"
+      - "communication_style"
+      - "deployment_strategy"
+      - "cost_estimation"
+  - name: "Event-Driven Architecture"
+    category: "cloud-native"
+    hints:
+      - "message broker"
+      - "event bus"
+      - "pub/sub"
+    report_fields:
+      - "broker_type"
+      - "event_formats"
+      - "delivery_guarantees"
+      - "cost_estimation"
+  - name: "Serverless Pattern"
+    category: "cloud-native"
+    hints:
+      - "faas"
+      - "function as a service"
+      - "serverless framework"
+    report_fields:
+      - "platform"
+      - "cold_start_mitigation"
+      - "scaling_events"
+      - "cost_estimation"
+  - name: "Container Orchestration"
+    category: "cloud-native"
+    hints:
+      - "kubernetes"
+      - "docker swarm"
+      - "scheduler"
+    report_fields:
+      - "cluster_size"
+      - "autoscaling"
+      - "resource_utilization"
+      - "cost_estimation"
+


### PR DESCRIPTION
## Summary
- add detection rules for common cloud architecture patterns
- document cloud service taxonomy across AWS, Azure, GCP and Kubernetes
- provide a prompt for auditing cloud configurations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687460ca0804832d8138de1af69d4d15